### PR TITLE
Fix imagemagick deprecation warning

### DIFF
--- a/pkg/default.nix
+++ b/pkg/default.nix
@@ -71,7 +71,7 @@ rec {
 } ''
   mkdir -p $out/share/wallpapers
   substituteAll ${../data/svg/wallpaper.svg} wallpaper.svg
-  convert \
+  magick \
     -resize ''${scale}% \
     -density $density \
     -background ''${backgroundColor}''${backgroundOpacity} \


### PR DESCRIPTION
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

Didn't test it locally though.