### PR TITLE
Switch to magick from deprecated magick convert

### DIFF
--- a/pkg/default.nix
+++ b/pkg/default.nix
@@ -91,12 +91,13 @@ runCommandLocal "nix-wallpaper"
   ''
     mkdir -p $out/share/wallpapers
     substituteAll ${../data/svg/wallpaper.svg} wallpaper.svg
-    magick convert \
-      -resize ''${scale}% \
+    magick \
       -density $density \
       -background ''${backgroundColor}''${backgroundOpacity} \
+      wallpaper.svg \
+      -resize ''${scale}% \
       -gravity center \
       -extent ''${width}x''${height} \
       $flop \
-      wallpaper.svg $out/share/wallpapers/nixos-wallpaper.png
+      $out/share/wallpapers/nixos-wallpaper.png
   ''


### PR DESCRIPTION
magick convert has given deprecation warnings for some time now, and there is a new API, which changes a little. It suffices to reorder the arguments a little to get equivalent results. As far as I understood, the arguments get applied in order. So once the input SVG is loaded, it's immediately rasterized, that's why we need to set the density and background before the wallpaper.svg. The rest of the options just applies sequentially to get the same output as before.