### PR TITLE
Add transrights.png

### DIFF
--- a/transrights.png
+++ b/transrights.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18e2ae585aa72eafc2dea273ae21ab5f3a83f1f01f905a0af3af5dfd99dbab6a
+size 20506


### PR DESCRIPTION
When the transrights preset was added, apparently it was left out when generating the assets. This adds the generated image to the assets branch, a subsequent PR will modify the readme accordingly.