### PR TITLE
Add support for custom tagline

### DIFF
--- a/pkg/default.nix
+++ b/pkg/default.nix
@@ -7,6 +7,11 @@
   width ? 3840,
   height ? 2160,
   logoSize ? 44.25,
+  fontFamily ? "DejaVueSans",
+  fontSize ? 150,
+  fontColor ? "black",
+  taglineOffset ? { x = 0; y = 0; },
+  tagline ? "",
 
   backgroundColor ? null,
   logoColors ? { },
@@ -64,7 +69,9 @@ let
 in
 runCommandLocal "nix-wallpaper"
   rec {
-    inherit width height;
+    inherit width height fontFamily fontSize fontColor tagline;
+    taglineX = taglineOffset.x;
+    taglineY = taglineOffset.y;
     inherit (colorscheme)
       color0
       color1
@@ -99,5 +106,12 @@ runCommandLocal "nix-wallpaper"
       -gravity center \
       -extent ''${width}x''${height} \
       $flop \
+  '' + lib.optionalString (tagline != "") ''
+      -font ''${fontFamily} \
+      -pointsize ''${fontSize} \
+      -fill ''${fontColor} \
+      -gravity center \
+      -annotate +''${taglineX}+''${taglineY} "''${tagline}" \
+  '' + ''
       $out/share/wallpapers/nixos-wallpaper.png
   ''


### PR DESCRIPTION
I see value in being able to place a custom tagline on the wallpaper. What are your thoughts on this?


Unfortunately magick cannot find the fontconfig:

```
       > Fontconfig error: No writable cache directories
       >        /var/cache/fontconfig
       >        /homeless-shelter/.cache/fontconfig
       > magick: unable to read font `DejaVueSans' @ warning/annotate.c/RenderType/1024
```

Any one have an idea what might cause this?
       